### PR TITLE
Add due date field to tasks

### DIFF
--- a/app.js
+++ b/app.js
@@ -18,7 +18,8 @@ if (process.env.NODE_ENV !== 'test') {
 
 
 const itemSchema = new mongoose.Schema({
-  name: String
+  name: String,
+  dueDate: Date
 });
 
 const Item = mongoose.model('item', itemSchema);
@@ -72,10 +73,12 @@ app.get("/", function(req, res) {
 app.post("/", function(req, res){
 
 const itemName = req.body.newItem;
+const itemDueDate = req.body.dueDate;
 const listName = req.body.list;
 
 const item = new Item({
-  name: itemName
+  name: itemName,
+  dueDate: itemDueDate || undefined
 });
 
 if (listName === "Today"){

--- a/public/css/styles.css
+++ b/public/css/styles.css
@@ -145,3 +145,9 @@ footer {
   text-align: center;
   padding: 20px 0; /* More vertical padding */
 }
+
+.due-date {
+  margin-left: 10px;
+  font-size: 0.8em;
+  color: #666;
+}

--- a/views/list.ejs
+++ b/views/list.ejs
@@ -17,6 +17,9 @@
             onchange="this.form.submit()"
           />
           <span><%= item.name %></span>
+          <% if (item.dueDate) { %>
+            <small class="due-date">(<%= new Date(item.dueDate).toLocaleDateString() %>)</small>
+          <% } %>
         </label>
         <input type="hidden" name="listName" value="<%= listTitle %>" />
       </form>
@@ -30,6 +33,10 @@
       name="newItem"
       placeholder="New item"
       autocomplete="off"
+    />
+    <input
+      type="date"
+      name="dueDate"
     />
     <button type="submit" name="list" value="<%= listTitle %>">+</button>
   </form>


### PR DESCRIPTION
## Summary
- add `dueDate` to the task schema
- store the due date from the form when creating tasks
- display due dates next to each item in the list
- allow users to pick a due date when adding a task
- style due dates in CSS

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847131841ac8321a58cb380023cd538